### PR TITLE
check for result

### DIFF
--- a/lib/components/ConfigForm.js
+++ b/lib/components/ConfigForm.js
@@ -189,7 +189,9 @@ WARNING: This action CAN NOT be undone.`
       // connection failed with specific node errors
       // these return as 200 because bcurl sanitizes out the specific
       // non-standard failure messages
-      if (result.failed) {
+      // need to check if result exists because sometimes a successful
+      // response comes back with null
+      if (result && result.failed) {
         this.setState({ error: result });
       } else {
         alert(`Successfully updated configs for ${_id}`);


### PR DESCRIPTION
Fixes a bug when result back from server is `null`.

I didn't get this all the time, but to reproduce try submitting random changes to a config (they can be "non valid" ones too, like `{"foo":"bar"}`)